### PR TITLE
Argon2 lib has different ordinal mapping...

### DIFF
--- a/src/main/java/de/mkammerer/argon2/Argon2Factory.java
+++ b/src/main/java/de/mkammerer/argon2/Argon2Factory.java
@@ -116,20 +116,20 @@ public final class Argon2Factory {
         /**
          * Argon2i.
          */
-        ARGON2i,
+        ARGON2i(1),
         /**
          * Argon2d.
          */
-        ARGON2d,
+        ARGON2d(0),
         /**
          * Argon2id
          */
-        ARGON2id;
+        ARGON2id(2);
 
         private final Argon2_type jnaType;
 
-        Argon2Types() {
-            this.jnaType = new Argon2_type(this.ordinal());
+        Argon2Types(int idx) {
+            this.jnaType = new Argon2_type(idx);
         }
 
         public Argon2_type getJnaType() {


### PR DESCRIPTION
for Argon2_type -- argon2d is "0", argon2i is "1", and argon2id is "2". 

This seems to impact only encoded_len function for now, but worth making the correction for next release.

Source for change: 

P-H-C reference: https://github.com/P-H-C/phc-winner-argon2/blob/master/include/argon2.h#L221
WOnder93 impl: https://github.com/WOnder93/argon2/blob/master/include/argon2.h#L215